### PR TITLE
Added /health endpoint and integrate route

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -196,7 +196,6 @@
       "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2067,7 +2066,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import dotenv from "dotenv";
 import authRoutes from "./routes/authRoutes.js";
+import healthRoutes from "./routes/healthRoutes.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 
 dotenv.config();
@@ -10,6 +11,7 @@ app.use(express.json());
 
 // Routes
 app.use("/api/auth", authRoutes);
+app.use("/api/health", healthRoutes);
 
 // Error Handler
 app.use(errorHandler);

--- a/server/src/controllers/healthController.ts
+++ b/server/src/controllers/healthController.ts
@@ -1,0 +1,9 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export const healthCheck = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    return res.status(200).json({ status: 'ok' });// Responds with { status: "ok" } if server is running
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/routes/healthRoutes.ts
+++ b/server/src/routes/healthRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { healthCheck } from '../controllers/healthController.js';
+
+
+const router = Router();
+router.get('/', healthCheck);
+
+export default router;


### PR DESCRIPTION
## Description

This pull request adds a new /api/health endpoint to the backend.
The endpoint provides a simple health check response ({ status: "ok" }) that can be used by deployment platforms, monitoring tools, or developers to verify that the server is running and responding correctly.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> closes #24 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

